### PR TITLE
QD Security Vulnerability Declaration: REP 2006

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,8 +4,8 @@
   <name>crasher</name>
   <version>0.0.0</version>
   <description>TODO: Package description</description>
-  <maintainer email="clalancette@openrobotics.org">ubuntu</maintainer>
-  <license>TODO: License declaration</license>
+  <maintainer email="clalancette@openrobotics.org">Chris Lalancette</maintainer>
+  <license>BSD</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
This PR adds a link to REP-2006 (the Security Vulnerability Declaration) to the Quality Declaration for this repository.
Part of clalancette/rclcpp_event_crash#5